### PR TITLE
fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-- 1.4
-- 1.5
+- 1.13
+- 1.14
 - tip
 notifications:
   email:

--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -345,7 +345,7 @@ func TestAutocomplete(t *testing.T) {
 	model.Train(sampleEnglish)
 	out, err := model.Autocomplete("accoun")
 	if err != nil {
-		t.Errorf("Auocomplete() returned and error: ", err)
+		t.Errorf("Autocomplete() returned an error: %s", err)
 	}
 	expected := map[string]bool{
 		"account":    true,
@@ -375,7 +375,7 @@ func TestAutocompleteFromQueries(t *testing.T) {
 
 	out, err := model.Autocomplete("eve")
 	if err != nil {
-		t.Errorf("Auocomplete() returned and error: ", err)
+		t.Errorf("Autocomplete() returned an error: %s", err)
 	}
 	if out[0] != "everest" {
 		t.Errorf("Autocomplete failed to account for query training")


### PR DESCRIPTION
Hello.  This pr corrects failing tests:

```
./fuzzy_test.go:348: Errorf call has arguments but no formatting directives
./fuzzy_test.go:378: Errorf call has arguments but no formatting directives
```
and bumps travis config to recent golang versions.